### PR TITLE
Compose Code usage cleanup 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /app/build/
 /app/build/intermediates/javac/debug/classes/
 /.idea/vcs.xml
+/local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,17 +40,19 @@ android {
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
-
+    implementation platform('androidx.compose:compose-bom:2023.05.00')
     implementation("androidx.graphics:graphics-shapes:1.0.0-alpha02")
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation("androidx.activity:activity-compose:1.7.1")
-    implementation("androidx.compose.foundation:foundation:1.4.2")
-    implementation("androidx.compose.foundation:foundation-layout:1.4.2")
-    implementation("androidx.compose.material:material:1.4.2")
-    implementation("androidx.compose.runtime:runtime:1.4.2")
-    implementation("androidx.compose.ui:ui:1.4.2")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation-layout")
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.runtime:runtime")
+    implementation("androidx.compose.ui:ui")
     implementation("androidx.core:core-ktx:1.10.0")
     implementation("androidx.fragment:fragment:1.5.7")
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.4.3'
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.4.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0'
+        kotlinCompilerExtensionVersion compose_compiler_version
     }
 }
 
@@ -53,6 +53,6 @@ dependencies {
     implementation("androidx.core:core-ktx:1.10.0")
     implementation("androidx.fragment:fragment:1.5.7")
     implementation 'com.google.android.material:material:1.9.0'
-    implementation 'androidx.compose.ui:ui-tooling-preview:1.4.3'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling:1.4.3'
 }

--- a/app/src/main/java/dev/chet/graphics/shapes/shapesdemo/compose/ShapeEditor.kt
+++ b/app/src/main/java/dev/chet/graphics/shapes/shapesdemo/compose/ShapeEditor.kt
@@ -16,8 +16,6 @@
 
 package dev.chet.graphics.shapes.shapesdemo.compose
 
-import android.graphics.PointF
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
@@ -44,9 +42,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.chet.graphics.shapes.shapesdemo.ShapeParameters
-import kotlin.math.cos
 import kotlin.math.roundToInt
-import kotlin.math.sin
 
 @Composable
 fun ShapeEditor(params: ShapeParameters, onClose: () -> Unit) {

--- a/app/src/main/java/dev/chet/graphics/shapes/shapesdemo/compose/ShapesAndMorphsActivity.kt
+++ b/app/src/main/java/dev/chet/graphics/shapes/shapesdemo/compose/ShapesAndMorphsActivity.kt
@@ -27,11 +27,15 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -49,11 +53,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposePath
-import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
 import androidx.graphics.shapes.Morph
@@ -125,19 +129,25 @@ private fun MorphComposableImpl(
     sizedMorph: SizedMorph,
     modifier: Modifier = Modifier,
     isDebug: Boolean = false,
-    prep: ContentDrawScope.() -> Unit
+    // todo remove this
+    prep: DrawScope.() -> Unit
 ) {
-    Box(
+    Spacer(
         modifier
             .fillMaxSize()
-            .drawWithContent {
-                prep()
-                drawContent()
+            .drawWithCache {
                 sizedMorph.resizeMaybe(size.width, size.height)
-                if (isDebug) {
-                    debugDraw(sizedMorph.morph)
-                } else {
-                    drawPath(sizedMorph.morph.asPath().asComposePath(), Color.White)
+                onDrawBehind {
+                    prep()
+                    if (isDebug) {
+                        debugDraw(sizedMorph.morph)
+                    } else {
+                        drawPath(
+                            sizedMorph.morph
+                                .asPath()
+                                .asComposePath(), Color.White
+                        )
+                    }
                 }
             })
 }
@@ -148,26 +158,27 @@ internal fun PolygonComposableImpl(
     modifier: Modifier = Modifier,
     debug: Boolean = false
 ) {
-    val sizedPolygonCache = remember(shape) {
-        mutableMapOf<Size, RoundedPolygon>()
-    }
-    Box(
+    Spacer(
         modifier
             .fillMaxSize()
-            .drawWithContent {
-                drawContent()
-                val sizedPolygon = sizedPolygonCache.getOrPut(size) {
-                    val matrix = calculateMatrix(TheBounds, size.width, size.height)
-                    RoundedPolygon(shape).apply { transform(matrix) }
-                }
-                if (debug) {
-                    debugDraw(sizedPolygon.toCubicShape())
-                } else {
-                    drawPath(sizedPolygon.toPath().asComposePath(), Color.White)
+            .drawWithCache {
+                val matrix = calculateMatrix(TheBounds, size.width, size.height)
+                val sizedPolygon = RoundedPolygon(shape).apply { transform(matrix) }
+                onDrawBehind {
+                    if (debug) {
+                        debugDraw(sizedPolygon.toCubicShape())
+                    } else {
+                        drawPath(
+                            sizedPolygon
+                                .toPath()
+                                .asComposePath(), Color.White
+                        )
+                    }
                 }
             })
 }
 
+@Preview
 @Composable
 fun MainScreen() {
     var editing by remember { mutableStateOf<ShapeParameters?>(null) }
@@ -279,6 +290,7 @@ fun MainScreen() {
     } ?: MorphScreen(shapes, selectedShape) { editing = shapes[selectedShape.value] }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MorphScreen(
     shapeParams: List<ShapeParameters>,
@@ -324,34 +336,33 @@ fun MorphScreen(
     }
     Column(
         Modifier
-            .fillMaxSize()
             .background(Color.Black)
+            .padding(16.dp)
+            .fillMaxSize()
+
     ) {
-        repeat(3) { rowIx ->
-            Row(Modifier.fillMaxWidth()) {
-                repeat(5) { columnIx ->
-                    val shapeIx = rowIx * 5 + columnIx
-                    val borderAlpha = (
-                        (if (shapeIx == selectedShape.value) progress.value else 0f) +
-                        (if (shapeIx == currShape) 1 - progress.value else 0f)
-                    ).coerceIn(0f, 1f)
-                    Box(
-                        Modifier
-                            .weight(1f)
-                            .aspectRatio(1f)
-                            .padding(horizontal = 5.dp)
-                            .border(
-                                3.dp,
-                                Color.Red.copy(alpha = borderAlpha)
-                            )
-                    ) {
-                        // draw shape
-                        val shape = shapes[shapeIx]
-                        PolygonComposable(shape, Modifier.clickable { clickFn(shapeIx) })
-                    }
+        FlowRow(Modifier.fillMaxWidth(), maxItemsInEachRow = 5) {
+            shapes.forEachIndexed { index, shape ->
+                val borderAlpha = (
+                        (if (index == selectedShape.value) progress.value else 0f) +
+                                (if (index == currShape) 1 - progress.value else 0f)
+                        ).coerceIn(0f, 1f)
+                Box(
+                    Modifier
+                        .weight(1f)
+                        .aspectRatio(1f)
+                        .padding(horizontal = 5.dp)
+                        .border(
+                            3.dp,
+                            Color.Red.copy(alpha = borderAlpha)
+                        )
+                ) {
+                    // draw shape
+                    PolygonComposable(shape, Modifier.clickable { clickFn(index) })
                 }
             }
         }
+
         Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
             Button(onClick = { debug = !debug }) {
                 Text(if (debug) "Debug" else "Shape")

--- a/app/src/main/java/dev/chet/graphics/shapes/shapesdemo/compose/ShapesAndMorphsActivity.kt
+++ b/app/src/main/java/dev/chet/graphics/shapes/shapesdemo/compose/ShapesAndMorphsActivity.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -44,7 +43,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Slider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -53,9 +51,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
@@ -74,16 +74,13 @@ fun PolygonComposable(polygon: RoundedPolygon, modifier: Modifier = Modifier) =
 @Composable
 private fun MorphComposable(
     sizedMorph: SizedMorph,
-    progress: Float,
+    progress: () -> Float,
     modifier: Modifier = Modifier,
     isDebug: Boolean = false
-)  {
-    LaunchedEffect(progress) {
-        sizedMorph.morph.progress = progress
+) =
+    MorphComposableImpl(sizedMorph, modifier, isDebug) {
+        sizedMorph.morph.progress = progress()
     }
-    MorphComposableImpl(sizedMorph, modifier, isDebug)
-}
-
 
 internal fun calculateMatrix(bounds: RectF, width: Float, height: Float): Matrix {
     val originalWidth = bounds.right - bounds.left
@@ -130,22 +127,24 @@ private class SizedMorph(val morph: Morph) {
 private fun MorphComposableImpl(
     sizedMorph: SizedMorph,
     modifier: Modifier = Modifier,
-    isDebug: Boolean = false
+    isDebug: Boolean = false,
+    prep: ContentDrawScope.() -> Unit
 ) {
-    Spacer(
+    Box(
         modifier
             .fillMaxSize()
-            .drawWithCache {
+            .drawWithContent {
+                prep()
+                drawContent()
                 sizedMorph.resizeMaybe(size.width, size.height)
-                val path = sizedMorph.morph
-                    .asPath()
-                    .asComposePath()
-                onDrawBehind {
-                    if (isDebug) {
-                        debugDraw(sizedMorph.morph)
-                    } else {
-                        drawPath(path, Color.White)
-                    }
+                if (isDebug) {
+                    debugDraw(sizedMorph.morph)
+                } else {
+                    drawPath(
+                        sizedMorph.morph
+                            .asPath()
+                            .asComposePath(), Color.White
+                    )
                 }
             })
 }
@@ -156,22 +155,26 @@ internal fun PolygonComposableImpl(
     modifier: Modifier = Modifier,
     debug: Boolean = false
 ) {
-    Spacer(
+    val sizedPolygonCache = remember(shape) {
+        mutableMapOf<Size, RoundedPolygon>()
+    }
+    Box(
         modifier
             .fillMaxSize()
-            .drawWithCache {
-                val matrix = calculateMatrix(TheBounds, size.width, size.height)
-                val sizedPolygon = RoundedPolygon(shape).apply { transform(matrix) }
-                onDrawBehind {
-                    if (debug) {
-                        debugDraw(sizedPolygon.toCubicShape())
-                    } else {
-                        drawPath(
-                            sizedPolygon
-                                .toPath()
-                                .asComposePath(), Color.White
-                        )
-                    }
+            .drawWithContent {
+                drawContent()
+                val sizedPolygon = sizedPolygonCache.getOrPut(size) {
+                    val matrix = calculateMatrix(TheBounds, size.width, size.height)
+                    RoundedPolygon(shape).apply { transform(matrix) }
+                }
+                if (debug) {
+                    debugDraw(sizedPolygon.toCubicShape())
+                } else {
+                    drawPath(
+                        sizedPolygon
+                            .toPath()
+                            .asComposePath(), Color.White
+                    )
                 }
             })
 }
@@ -372,7 +375,7 @@ fun MorphScreen(
         Slider(value = progress.value.coerceIn(0f, 1f), onValueChange = {
             scope.launch { progress.snapTo(it) }
         })
-        MorphComposable(morphed, progress.value,
+        MorphComposable(morphed, { progress.value },
             Modifier
                 .fillMaxSize()
                 .clickable(

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.0' apply false
+buildscript {
+    ext {
+        compose_compiler_version = '1.4.3'
+    }
 }
 
+plugins {
+    id 'com.android.application' version '8.0.1' apply false
+    id 'com.android.library' version '8.0.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Apr 05 14:18:57 PDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Small improvements:
* Using Compose BOM instead of hardcoded Compose version, upgrade Compose compiler version and gradle version.
* Changed `Row` + `Column` usage to `FlowRow` with max 5 items per row.
* Changed `drawWithContent` usage to `drawWithCache` to cache results and remove unnecessary `drawContent` call.
* Added `@Preview` to `MainScreen` to get Android Studio previews. 

